### PR TITLE
chore: fix git url at packagejson

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/module-federation/automatic-vendor-sharing.git"
+    "url": "https://github.com/module-federation/automatic-vendor-federation.git"
   },
   "dependencies": {
     "find-package-json": "^1.2.0"


### PR DESCRIPTION
I saw the git url was wrong when studying the repo.
